### PR TITLE
Update module.js

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -186,7 +186,7 @@ Hooks.once('ready', async function() {
 
             game.falemos.sprite = new PIXI.Sprite(PIXI.Texture.from(video));
 
-            canvas.app.stage.addChild(game.falemos.sprite);
+            canvas.primary.addChild(game.falemos.sprite);
 
             game.falemos.sprite.width = canvas.dimensions.width;
             game.falemos.sprite.height = canvas.dimensions.height;


### PR DESCRIPTION
changing line 189 from

canvas.app.stage.addChild(game.falemos.sprite);

to 

canvas.primary.addChild(game.falemos.sprite);

V10 safe. Prevents video from covering tokens and tiles when it is set to the background.