### PR TITLE
Force reload when falemos is off

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -383,8 +383,8 @@ Hooks.on('closeSceneConfig', async function(sceneConfig, html, data) {
                 canvasFit('contain');
                 break;
         }
-		location.reload()
     }
+	location.reload()
 });
 
 


### PR DESCRIPTION
If not, camera min size is 100px, instead of 240px default