### PR TITLE
Fit code totally rewritten and bugfixes

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -59,6 +59,8 @@
     "FALEMOS.scene.fit.nofit": "No fit",
     "FALEMOS.scene.fit.cover": "Fit to cover",
     "FALEMOS.scene.fit.contain": "Fit to contain",
+    "FALEMOS.scene.fit.covercenter": "Fit to cover and center",
+    "FALEMOS.scene.fit.containcenter": "Fit to contain and center",
     "FALEMOS.SceneFitText": "Scene fit",
     "FALEMOS.SceneFitNotes": "Fit the scene so that the image covers the entire scene or so that the image is seen in its entirety.",
     "FALEMOS.ExportConfigToMacro": "Create macro",

--- a/languages/es.json
+++ b/languages/es.json
@@ -59,6 +59,8 @@
     "FALEMOS.scene.fit.nofit": "Sin ajuste de escena",
     "FALEMOS.scene.fit.cover": "Cubrir con la imagen",
     "FALEMOS.scene.fit.contain": "Contener la imagen",
+    "FALEMOS.scene.fit.covercenter": "Cubrir con la imagen y centrar",
+    "FALEMOS.scene.fit.containcenter": "Contener la imagen y centrar",
     "FALEMOS.SceneFitText": "Ajuste de la escena",
     "FALEMOS.SceneFitNotes": "Ajusta la escena para que la imagen la cubra entera o para que la imagen se vea entera",
     "FALEMOS.ExportConfigToMacro": "Crear macro",

--- a/scripts/utils/falemosVaccinator.js
+++ b/scripts/utils/falemosVaccinator.js
@@ -1,5 +1,5 @@
 //
-// falemos vaccinator 0.14
+// falemos vaccinator 0.15
 // by Viriato139ac
 //
 
@@ -839,8 +839,14 @@ function simularTabla(
           <option value="cover">${game.i18n.localize(
             "FALEMOS.scene.fit.cover"
           )}</option>
+          <option value="covercenter">${game.i18n.localize(
+            "FALEMOS.scene.fit.covercenter"
+          )}</option>
           <option value="contain">${game.i18n.localize(
             "FALEMOS.scene.fit.contain"
+          )}</option>
+          <option value="containcenter">${game.i18n.localize(
+            "FALEMOS.scene.fit.containcenter"
           )}</option>
         </select></td>
       </tr>


### PR DESCRIPTION
* Fit adjustment code totally rewritten
* Added new fit modes (containcenter and covercenter)
* Fixed bug, to reset the css code when falemos is disabled, to avoid the missplacing of nav buttons when falemos is enabled and dock is to the left
* Fixed bug, to remove the min-camera of 100px falemos config, and revert to 240px foundry default, that caused small cameras when using the bottom dock