### PR TITLE
Reset to left positioning

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -160,6 +160,17 @@ Hooks.once('ready', async function() {
 //                 }
 //             }
 //             console.log(data);
+if (!data.enable && game.scenes.viewed.flags.falemos.config.enable){
+	    let rtcSett = game.settings.get("core", "rtcClientSettings")
+
+    rtcSett.dockPosition = "left";
+    rtcSett.hideDock = false;
+    for(let [k,v] of Object.entries(game.settings.get("core", "rtcClientSettings").users)){
+        v.popout = false;
+        rtcSett.users[k] = v;
+    }
+    game.settings.set("core", "rtcClientSettings", rtcSett);
+}
             game.scenes.get(sceneId).setFlag('falemos', 'config', newData);
         },
         sceneConfigToMacro: function (sceneId, data) {


### PR DESCRIPTION
When disabling falemos using macros, it resets the camera dock to left, to avoid the 100px limit set by falemos, as a workaround since I am not able to reset it back to 240px